### PR TITLE
Add support for wildcard subdomains

### DIFF
--- a/ec2_server.go
+++ b/ec2_server.go
@@ -12,13 +12,14 @@ type EC2Server struct {
 	domain   string
 	hostname string
 	cache    *EC2Cache
+	wildcard bool
 }
 
 type response struct {
 	*dns.Msg
 }
 
-func NewEC2Server(domain string, hostname string, cache *EC2Cache) *EC2Server {
+func NewEC2Server(domain string, hostname string, cache *EC2Cache, wildcard bool) *EC2Server {
 
 	if !strings.HasSuffix(domain, ".") {
 		domain += "."
@@ -31,6 +32,7 @@ func NewEC2Server(domain string, hostname string, cache *EC2Cache) *EC2Server {
 		domain:   domain,
 		hostname: hostname,
 		cache:    cache,
+		wildcard: wildcard,
 	}
 
 	dns.HandleFunc(server.domain, server.handleRequest)
@@ -119,6 +121,10 @@ func (s *EC2Server) Lookup(msg dns.Question) []*Record {
 
 	nth := 0
 	tag := LOOKUP_NAME
+
+	if s.wildcard {
+		parts = parts[len(parts)-1:]
+	}
 
 	// handle role lookup, e.g. web.role.internal
 	if len(parts) > 1 {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 const USAGE = `Usage: aws-name-server --domain <domain>
                      [ --hostname <hostname>
+                       --wildcard
                        --aws-region us-east-1
                        --aws-access-key-id <access-key>
                        --aws-secret-access-key <secret-key> ]
@@ -41,6 +42,7 @@ Just run it as root (not recommended):
 func main() {
 	domain := flag.String("domain", "", "the domain heirarchy to serve (e.g. aws.example.com)")
 	hostname := flag.String("hostname", "", "the public hostname of this server (e.g. ec2-12-34-56-78.compute-1.amazonaws.com)")
+	wildcard := flag.Bool("wildcard", false, "alias *.<name>.<domain> to <name>.<domain>")
 	help := flag.Bool("help", false, "show help")
 
 	region := flag.String("aws-region", "us-east-1", "The AWS Region")
@@ -68,7 +70,7 @@ func main() {
 		*hostname = <-hostnameFuture
 	}
 
-	server := NewEC2Server(*domain, *hostname, cache)
+	server := NewEC2Server(*domain, *hostname, cache, *wildcard)
 
 	log.Printf("Serving %d DNS records for *.%s from %s port 53", cache.Size(), server.domain, server.hostname)
 


### PR DESCRIPTION
My company has several staging and demo instances that we would like to resolve with aws-name-server. Every instance has a number of nginx virtualhosts corresponding to different services running on it; for example, we'd like foo.demo-5.ec2.elacarte.com and bar.demo-5.ec2.elacarte.com to both resolve to demo-5.ec2.elacarte.com. Unfortunately, aws-name-server doesn't seem to support this out of the box.

To get this functionality, this pull request adds a flag that causes `*.<name>.<domain>` to always resolve to `<name>.<domain>`. This is somewhat intrusive, but is fairly consistent -- any subdomain of `<name>.<domain>` will resolve to `<name>.<domain>`. A less intrusive but less consistent alternative would be to resolve all non-numeric subdomains to the instance name as in the diff below.

Note that I haven't updated the documentation yet -- I'd like to get feedback on what approach you prefer, even though both approaches are only minor changes.

``` diff
diff --git a/ec2_server.go b/ec2_server.go
index f02e48a..f1a64d0 100644
--- a/ec2_server.go
+++ b/ec2_server.go
@@ -132,8 +132,8 @@ func (s *EC2Server) Lookup(msg dns.Question) []*Record {
        if len(parts) > 1 {
                if i, err := strconv.Atoi(parts[0]); err == nil && i > 0 {
                        nth = i
-                       parts = parts[1:]
                }
+               parts = parts[1:]
        }

        if len(parts) != 1 || parts[0] == "" {
```
