### PR TITLE
Usage arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Usage
 =====
 
 ```
-aws-name-server --domain aws.bugsnag.com --aws-access-key-id <access_key> --aws-secret-access-key <secret_key>
+aws-name-server --domain aws.bugsnag.com \
+                --aws-access-key-id <access_key> \
+                --aws-secret-access-key <secret_key>
 ```
 
 This will serve up DNS records for the following:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Usage
 =====
 
 ```
-aws-name-server --domain aws.bugsnag.com --aws-access-key ACCESS --aws-secret-key SECRET
+aws-name-server --domain aws.bugsnag.com --aws-access-key-id <access_key> --aws-secret-access-key <secret_key>
 ```
 
 This will serve up DNS records for the following:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Usage
 
 ```
 aws-name-server --domain aws.bugsnag.com \
+                --aws-region us-east-1 \
                 --aws-access-key-id <access_key> \
                 --aws-secret-access-key <secret_key>
 ```


### PR DESCRIPTION
Hi Conrad,

Thanks for creating this, it seems to work pretty well.

I've got a a couple of minor tweaks to the example usage line that would have made it quicker for me to get started with it. 

* Corrects aws credential arguments: `aws-secret-key`-> `aws-access-key-id` and `aws-secret-key` -> `aws-secret-access-key` 
* Improving readability by moving arguments to separate lines
* adding `aws-region` to example usage

— Oliver